### PR TITLE
Show the status of frontend and backend workers in bbb-conf status

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -420,6 +420,20 @@ display_bigbluebutton_status () {
 
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then
         units="$units mongod bbb-html5 bbb-webrtc-sfu kurento-media-server"
+	
+	source /usr/share/meteor/bundle/bbb-html5-with-roles.conf
+
+	if [ -f /etc/bigbluebutton/bbb-html5-with-roles.conf ]; then
+	  source /etc/bigbluebutton/bbb-html5-with-roles.conf
+	fi
+
+	for ((i = 1 ; i <= $NUMBER_OF_BACKEND_NODEJS_PROCESSES; i++)); do
+          units="$units bbb-html5-backend@$i"
+        done
+	
+        for ((i = 1; i <= NUMBER_OF_FRONTEND_NODEJS_PROCESSES; i++)); do
+          units="$units bbb-html5-frontend@$i"
+        done
     fi
 
     if [ -f /usr/share/etherpad-lite/settings.json ]; then


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
```bbb-conf --status```  command outputs the status of each of the frontend and backend nodejs workers.

<!-- A brief description of each change being made with this pull request. -->

### Motivation

Moving from 2.2 where bbb-html5.service's status gave an idea of the actual status, people might be interested in knowing if all the backend and frontend workers are active (as bbb-html5.service's status doesn't express this and may give a false impression sometimes.)
<!-- What inspired you to submit this pull request? -->

### Screenshot


![image](https://user-images.githubusercontent.com/43332436/118048765-5d80f500-b39a-11eb-95e6-167622afb762.png)
