### PR TITLE
Fix no remove button for uploaded presentation with default filename.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -225,7 +225,8 @@ class PresentationUploader extends Component {
       disableActions: false,
       toUploadCount: 0,
     };
-
+    
+    this.defaultPresentationId = null;
     this.toastId = null;
     this.hasError = null;
 
@@ -273,6 +274,7 @@ class PresentationUploader extends Component {
     // set as selectedToBeNextCurrentOnConfirm once upload / coversion complete
     if (presentations.length === 0 && propPresentations.length === 1) {
       if (propPresentations[0].upload.done && propPresentations[0].conversion.done) {
+        this.defaultPresentationId = propPresentations[0].id;
         return this.setState({
           presentations: propPresentations,
         }, Session.set('selectedToBeNextCurrent', propPresentations[0].id));
@@ -302,7 +304,7 @@ class PresentationUploader extends Component {
   isDefault(presentation) {
     const { defaultFileName } = this.props;
     return presentation.filename === defaultFileName
-      && !presentation.id.includes(defaultFileName);
+      && presentation.id === this.defaultPresentationId;
   }
 
   handleDismissToast() {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Uploading a presentation with the name, same as default presentation name couldn't be removed after conversion. So we store the default pres. id to ensure only that can't be removed

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #7720




<!-- Anything else we should know when reviewing? -->

- Unfortunately, I haven't tested this patch. [Couldn't setup a dev env :( ]
